### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -125,7 +125,7 @@ std::string dts_compile(const std::string& dts)
     close(dts_pipe[1]);
     close(dtb_pipe[0]);
     close(dtb_pipe[1]);
-    execl(DTC, DTC, "-O", "dtb", 0);
+    execl(DTC, DTC, "-O", "dtb", (char *)NULL);
     std::cerr << "Failed to run " DTC ": " << strerror(errno) << std::endl;
     exit(1);
   }

--- a/riscv/remote_bitbang.cc
+++ b/riscv/remote_bitbang.cc
@@ -5,6 +5,13 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifndef AF_INET
+#include <sys/socket.h>
+#endif
+#ifndef INADDR_ANY
+#include <netinet/in.h>
+#endif
+
 #include <algorithm>
 #include <cassert>
 #include <cstdio>

--- a/riscv/rvfi_dii.cc
+++ b/riscv/rvfi_dii.cc
@@ -39,6 +39,13 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifndef AF_INET
+#include <sys/socket.h>
+#endif
+#ifndef INADDR_ANY
+#include <netinet/in.h>
+#endif
+
 #include <algorithm>
 #include <cassert>
 #include <cstdio>

--- a/riscv/rvfi_dii.h
+++ b/riscv/rvfi_dii.h
@@ -96,7 +96,7 @@ class sim_t;
 class rvfi_dii_interface_t
 {
 public:
-  virtual ~rvfi_dii_interface_t() = 0;
+  virtual ~rvfi_dii_interface_t() = default;
 
   // This function must be implemented by a RVDI-DII-supported platform to
   // read a RVDI-DII-supported execution command (also known as exceution trace)


### PR DESCRIPTION
The first one is only a warning and given the small number of args is probably harmless, but is more correct.