### PR TITLE
Store the CHERI exception code and capability index in tval.

### DIFF
--- a/cheri/cheri.h
+++ b/cheri/cheri.h
@@ -162,7 +162,7 @@ class cheri_t : public extension_t {
 
   void raise_trap(reg_t trap_code, reg_t trap_reg) {
     set_ccsr((trap_reg << 10) | (trap_code << 5));
-    throw trap_cheri_trap();
+    throw trap_cheri_trap((trap_reg << 5) | trap_code);
   };
 
   std::vector<insn_desc_t> get_instructions();

--- a/cheri/cheri_trap.h
+++ b/cheri/cheri_trap.h
@@ -38,5 +38,5 @@
 #include "trap.h"
 #include <stdlib.h>
 
-DECLARE_TRAP(CAUSE_CHERI_TRAP, cheri_trap)
+DECLARE_MEM_TRAP(CAUSE_CHERI_TRAP, cheri_trap)
 #endif


### PR DESCRIPTION
For now, spike reports these both in xCCSR and xTVAL.